### PR TITLE
Fix a typo on on the Auth page

### DIFF
--- a/src/containers/Auth.jsx
+++ b/src/containers/Auth.jsx
@@ -71,7 +71,7 @@ const Auth = () => {
           The only account information we save is your profile image & username.
         </Text>
         <Text as="p" weight="bold">
-          We do no not see your password or store it.
+          We do not see your password or store it.
         </Text>
 
         <GetStartedButton


### PR DESCRIPTION
Noticed a small typo regarding the password usage when I was signing up. This PR fixes that.